### PR TITLE
Venue url is now optional. Changed venue date to %B %Y.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,3 +14,4 @@ favicon = false
 large_card = true
 footer_text = "This website is built using [Zola](https://www.getzola.org) and the [Academic Paper](http://github.com/aterenin/academic-paper/) theme, which is [designed to last](https://jeffhuang.com/designed_to_last/)."
 server_side_katex = true
+base_author = "Alexander Terenin"

--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-base_url = "https://aterenin.github.io/academic-paper"
+base_url = "https://websites.umich.edu/~lmarques"
 compile_sass = true
 build_search_index = false
 generate_feeds = false
@@ -14,4 +14,3 @@ favicon = false
 large_card = true
 footer_text = "This website is built using [Zola](https://www.getzola.org) and the [Academic Paper](http://github.com/aterenin/academic-paper/) theme, which is [designed to last](https://jeffhuang.com/designed_to_last/)."
 server_side_katex = true
-base_author = "Alexander Terenin"

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,56 +1,6 @@
 +++
-title = "Academic Paper Zola Theme"
+title = "Redirect"
+template = "redirect.html"
 [extra]
-authors = [
-    {name = "Alexander Terenin", url = "https://avt.im/"},
-]
-venue = {name = "GitHub", url = "https://github.com/aterenin/academic-paper"}
-buttons = [
-    {name = "Paper", url = "https://aterenin.github.io/academic-paper"},
-    {name = "PDF", url = "https://aterenin.github.io/academic-paper"},
-    {name = "Code", url = "https://github.com/aterenin/academic-paper"},
-    {name = "Poster", url = "https://aterenin.github.io/academic-paper"},
-    {name = "Video", url = "https://aterenin.github.io/academic-paper"},
-]
-katex = true
-large_card = false
-favicon = false
+redirect_to = "https://websites.umich.edu/~lmarques"
 +++
-
-Welcome to the [Academic Paper](https://github.com/aterenin/academic-paper) Zola theme!
-This theme is designed for hosting a blog-post-style website to facilitate scientific communication of your academic paper.
-
-# Features
-
-[Academic Paper](https://github.com/aterenin/academic-paper) is designed to be reasonably feature-complete. In particular, it supports:
-
-* A header with title, author, publication venue, year, and optional buttons for the paper, PDF download link, code, poster, and video.
-* Syntax highlighting via Zola, with a minimal CSS-based color theme.
-* Math rendering via KaTeX, compatible with both client-side and server-side rendering when configured appropriately.
-* Figures via a `figure(alt='Image alt text',src='path/to/image.png')` Zola shortcode, with support for optional captions, subfigures with optional subcaptions, implemented in responsive manner via flexbox.
-* Markdown footnotes via Zola.
-* Twitter Summary Card, OpenGraph, and JSON-LD metadata, to ensure the web pages produced are search-engine-friendly, and provide social media websites with a banner image link they can display when the website is shared on social media, with an implementation very similar to [Jekyll SEO Tag](https://github.com/jekyll/jekyll-seo-tag).
-
-Let's demonstrate some of these: writing
-```tex
-$$
-\int_{\mathbb{R}} \frac{1}{\sqrt{2\pi\sigma^2}} \exp\left(\frac{(x-\mu)^2}{-2\sigma^2}\right) \mathrm{d} x = 1.
-$$
-```
-in the Markdown file produces the output
-```
-$$
-\int_{\mathbb{R}} \frac{1}{\sqrt{2\pi\sigma^2}} \exp\left(\frac{(x-\mu)^2}{-2\sigma^2}\right) \mathrm{d} x = 1.
-$$
-```
-This theme also supports footnotes, and will style the heading that immediately precedes them.[^author]
-
-# Design and maintainability
-
-[Academic Paper](https://github.com/aterenin/academic-paper) is [designed to last](https://jeffhuang.com/designed_to_last/), meaning that it follows a number of best practices to ensure the websites it produces continue to work correctly in the indefinite future with minimal to no maintenance.
-In particular, this theme uses no JavaScript or CSS dependencies, except optionally KaTeX for math.
-Zola, with its Rust-based code, focus on simplicity, and one-binary design, is the clear static site generator of choice for such a theme.
-
-# References
-
-[^author]: This theme is designed and built by Alexander Terenin.

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Academic Paper: a Zola theme
 
-[Academic Paper](https://aterenin.github.io/academic-paper) is a Zola theme desgned for hosting a website for scientific communication of an academic paper in the style of a blog post. 
+[Academic Paper](https://aterenin.github.io/academic-paper) is a Zola theme designed for hosting a website for scientific communication of an academic paper in the style of a blog post. 
 A demo website built with Academic Paper can be found at [aterenin.github.io/academic-paper](https://aterenin.github.io/academic-paper), and an example repository using this theme can be found at [github.com/aterenin/papers.avt.im](https://github.com/aterenin/papers.avt.im), with links to the pages in this repository found at [avt.im/archive?papers](https://avt.im/archive?papers).
 
 # Features
@@ -35,10 +35,12 @@ minify_html = true # to ensure correct rendering due to minification of whitespa
 [markdown]
 highlight_code = true # should be set to true unless the page has no code to highlight
 highlight_theme = "css" # this theme includes its own CSS-based styling of highlighting, so this should be set to CSS
+smart_punctuation = true # ... turns into ellipsis, quotes become curly, consecutive dashes turn into em/en dashes
 
 [extra]
 footer_text = "This website is built using [Zola](https://www.getzola.org) and the [Academic Paper](http://github.com/aterenin/academic-paper/) theme, which is [designed to last](https://jeffhuang.com/designed_to_last/)." # by default this page adds a small and non-intrusive footer with some text linking to this repository - you can set this to false to remove the footer if you prefer
 server_side_katex = false # set to true to enable server-side KaTeX rendering via scripts/katex.js, this will also include KaTeX CSS and fonts in the build
+base_author = "Alexander Terenin" # if you set this to be your name, your author's url will all redirected to the base_url - useful if you change webpage later domain
 ```
 
 ## Page and section configuration 

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,6 @@ smart_punctuation = true # ... turns into ellipsis, quotes become curly, consecu
 [extra]
 footer_text = "This website is built using [Zola](https://www.getzola.org) and the [Academic Paper](http://github.com/aterenin/academic-paper/) theme, which is [designed to last](https://jeffhuang.com/designed_to_last/)." # by default this page adds a small and non-intrusive footer with some text linking to this repository - you can set this to false to remove the footer if you prefer
 server_side_katex = false # set to true to enable server-side KaTeX rendering via scripts/katex.js, this will also include KaTeX CSS and fonts in the build
-base_author = "Alexander Terenin" # if you set this to be your name, your author's url will all redirected to the base_url - useful if you change webpage later domain
 ```
 
 ## Page and section configuration 

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,9 +12,13 @@
                 <h2>
                     <span itemprop="author">
                         {% for author in this.extra.authors %}
+                            {% if author.name == config.extra.base_author %}
+                                <a href="{{ config.base_url | safe }}">{{ config.extra.base_author }}</a>
+                            {% else %}
                             <a href="{{ author.url | default(value = this.path ~ '#') | safe }}">
                                 {{- author.name -}}
                             </a>
+                            {% endif %}
                             {%- if not loop.last -%}
                                 &comma;
                             {%- endif -%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -44,13 +44,22 @@
                     {% endfor %}
                 </div>
                 <h2>
-                    <a href="{{ this.extra.venue.url | default(value = this.extra.paper) | safe }}">
-                        <span itemprop="isPartOf" itemscope itemtype="http://schema.org/Periodical"><span itemprop="name">
-                            {{- this.extra.venue.name -}}
-                        </span></span>{% if this.extra.venue.date or this.date %}&nbsp;<time datetime="{{ this.extra.venue.date | default(value = this.date) | date(format='%+') }}" itemprop="datePublished">
-                            {{- this.extra.venue.date | default(value = this.date) | date(format='%Y') -}}
-                        </time>{% endif %}
+                    {% if this.extra.venue.url %}
+                    <a href="{{ this.extra.venue.url | default(value = this.path ~ '#') | safe }}">
+                    {% endif %}
+                    <span itemprop="isPartOf" itemscope itemtype="http://schema.org/Periodical">
+                        <span itemprop="name">
+                            {{- this.extra.venue.name -}},
+                        </span>
+                    </span>
+                    {% if this.extra.venue.date or this.date %}
+                        <time datetime="{{ this.extra.venue.date | default(value = this.date) | date(format='%+') }}" itemprop="datePublished">
+                            {{- this.extra.venue.date | default(value = this.date) | date(format='%B %Y') -}}
+                        </time>
+                    {% endif %}
+                    {% if this.extra.venue.url %}
                     </a>
+                    {% endif %}
                 </h2>
             </header>
         

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,13 +12,9 @@
                 <h2>
                     <span itemprop="author">
                         {% for author in this.extra.authors %}
-                            {% if author.name == config.extra.base_author %}
-                                <a href="{{ config.base_url | safe }}">{{ config.extra.base_author }}</a>
-                            {% else %}
                             <a href="{{ author.url | default(value = this.path ~ '#') | safe }}">
                                 {{- author.name -}}
                             </a>
-                            {% endif %}
                             {%- if not loop.last -%}
                                 &comma;
                             {%- endif -%}

--- a/theme.toml
+++ b/theme.toml
@@ -9,5 +9,5 @@ demo = "https://aterenin.github.io/academic-paper"
 footer_text = "This website is built using [Zola](https://www.getzola.org) and the [Academic Paper](http://github.com/aterenin/academic-paper/) theme, which is [designed to last](https://jeffhuang.com/designed_to_last/)."
 
 [author]
-name = "Alexander Terein"
+name = "Alexander Terenin"
 homepage = "https://avt.im"


### PR DESCRIPTION
Hi, congrats on this repo! I started using it today and it appears to be exactly what I was looking for. 

If no url is provided for the venue (e.g. some venues keep the same url across editions and so might become outdated with time), it now shows the venue name as normal text. Before it was linking to `this.extra.paper` which I could not find in the example `_index.md` provided. 

Also, should ` | default(value = this.path ~ '#')` be removed from both the venue url and the author url (it might be clearer to just show as normal text if there is no link attached, rather than a blue hyperlink pointing to the current page)? 

I changed the venue date to be `%B %Y%` instead of `%Y` (i.e. October 2024) instead of just (2024), but this can be rolled back as you wish. 

Best, Luis