### PR TITLE
Venue url is now optional. Changed venue date to %B %Y.

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -44,13 +44,22 @@
                     {% endfor %}
                 </div>
                 <h2>
-                    <a href="{{ this.extra.venue.url | default(value = this.extra.paper) | safe }}">
-                        <span itemprop="isPartOf" itemscope itemtype="http://schema.org/Periodical"><span itemprop="name">
-                            {{- this.extra.venue.name -}}
-                        </span></span>{% if this.extra.venue.date or this.date %}&nbsp;<time datetime="{{ this.extra.venue.date | default(value = this.date) | date(format='%+') }}" itemprop="datePublished">
-                            {{- this.extra.venue.date | default(value = this.date) | date(format='%Y') -}}
-                        </time>{% endif %}
+                    {% if this.extra.venue.url %}
+                    <a href="{{ this.extra.venue.url | default(value = this.path ~ '#') | safe }}">
+                    {% endif %}
+                    <span itemprop="isPartOf" itemscope itemtype="http://schema.org/Periodical">
+                        <span itemprop="name">
+                            {{- this.extra.venue.name -}},
+                        </span>
+                    </span>
+                    {% if this.extra.venue.date or this.date %}
+                        <time datetime="{{ this.extra.venue.date | default(value = this.date) | date(format='%+') }}" itemprop="datePublished">
+                            {{- this.extra.venue.date | default(value = this.date) | date(format='%B %Y') -}}
+                        </time>
+                    {% endif %}
+                    {% if this.extra.venue.url %}
                     </a>
+                    {% endif %}
                 </h2>
             </header>
         


### PR DESCRIPTION
Hi, congrats on this repo! I started using it today and it appears to be exactly what I was looking for.

If no url is provided for the venue (e.g. some venues keep the same url across editions and so might become outdated with time), it now shows the venue name as normal text. Before it was linking to `this.extra.paper` which I could not find in the example `_index.md` provided.

Also, should  `| default(value = this.path ~ '#')` be removed from both the venue url and the author url (it might be clearer to just show as normal text if there is no link attached, rather than a blue hyperlink pointing to the current page)?

I changed the venue date to be `%B %Y%` instead of `%Y` (i.e. October 2024) instead of just (2024), but this can be rolled back as you wish.

Best, Luis

PS: There was a duplicate pull request (closed it) since I kept making changes to my fork and it added those commits later to the pull request? Ups xD